### PR TITLE
chore: use bdk 1.0.0-beta.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ Cargo.lock
 .idea
 *.swp
 .cargo
-.npmrc
+
 bin/
 pkg/
 wasm-pack.log

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ Cargo.lock
 .idea
 *.swp
 .cargo
-
+.npmrc
 bin/
 pkg/
 wasm-pack.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ getrandom = { version = "0.2.15", features = ["js"] }
 ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"] }
 
 # Bitcoin dependencies
-bdk_wallet = { git = "https://github.com/bitcoindevkit/bdk", branch = "master" }
-bdk_esplora = { git = "https://github.com/bitcoindevkit/bdk", branch = "master", default-features = false, features = [
+bdk_wallet = { version = "1.0.0-beta.5" }
+bdk_esplora = { version = "0.19", default-features = false, features = [
     "async-https",
 ], optional = true }
 bitcoin = { version = "0.32.4", default-features = false }
@@ -57,9 +57,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 [dev-dependencies]
 wasm-bindgen-test = "0.3.45"
 web-sys = { version = "0.3.72", features = ["console"] }
-bdk_wallet = { git = "https://github.com/bitcoindevkit/bdk", branch = "master", features = [
-    "keys-bip39",
-] }
+bdk_wallet = { version = "1.0.0-beta.5", features = ["keys-bip39"] }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/src/bitcoin/esplora_wallet.rs
+++ b/src/bitcoin/esplora_wallet.rs
@@ -124,7 +124,7 @@ impl EsploraWallet {
             .await?;
 
         let now = (Date::now() / 1000.0) as u64;
-        self.wallet.apply_update_at(update, now)?;
+        self.wallet.apply_update_at(update, Some(now))?;
 
         Ok(())
     }
@@ -134,7 +134,7 @@ impl EsploraWallet {
         let update = self.client.sync(request, parallel_requests).await?;
 
         let now = (Date::now() / 1000.0) as u64;
-        self.wallet.apply_update_at(update, now)?;
+        self.wallet.apply_update_at(update, Some(now))?;
 
         Ok(())
     }

--- a/src/bitcoin/snap_wallet.rs
+++ b/src/bitcoin/snap_wallet.rs
@@ -134,7 +134,7 @@ impl SnapWallet {
             .await?;
 
         let now = (Date::now() / 1000.0) as u64;
-        self.wallet.apply_update_at(update, now)?;
+        self.wallet.apply_update_at(update, Some(now))?;
 
         Ok(())
     }
@@ -144,7 +144,7 @@ impl SnapWallet {
         let update = self.client.sync(request, parallel_requests).await?;
 
         let now = (Date::now() / 1000.0) as u64;
-        self.wallet.apply_update_at(update, now)?;
+        self.wallet.apply_update_at(update, Some(now))?;
 
         Ok(())
     }


### PR DESCRIPTION
### Description

Use bdk 1.0.0-beta.5

### Notes to the reviewers

Using `master` is not a good idea as it can change the API without further notice. We should be compatible with `1.0.0-beta.5` and eventually to `1.x`
