### PR TITLE
fix: linting

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+newline_style = "Unix"

--- a/src/bitcoin/descriptor.rs
+++ b/src/bitcoin/descriptor.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, Error};
 use bdk_wallet::{
     keys::{DerivableKey, ExtendedKey},
     template::{
-        Bip44, Bip44Public, Bip49, Bip49Public, Bip84, Bip84Public, Bip86, Bip86Public,
-        DescriptorTemplate, DescriptorTemplateOut,
+        Bip44, Bip44Public, Bip49, Bip49Public, Bip84, Bip84Public, Bip86, Bip86Public, DescriptorTemplate,
+        DescriptorTemplateOut,
     },
     KeychainKind,
 };
@@ -62,10 +62,7 @@ pub fn xpub_to_descriptor(
     }
 }
 
-pub fn slip10_to_extended(
-    node: SLIP10Node,
-    network: Network,
-) -> Result<ExtendedKey, anyhow::Error> {
+pub fn slip10_to_extended(node: SLIP10Node, network: Network) -> Result<ExtendedKey, anyhow::Error> {
     let parent_fingerprint: Fingerprint = node.parent_fingerprint.to_be_bytes().into();
     let chain_code = ChainCode::from_hex(strip_0x_prefix(&node.chain_code))?;
 

--- a/src/bitcoin/esplora_wallet.rs
+++ b/src/bitcoin/esplora_wallet.rs
@@ -37,7 +37,7 @@ impl EsploraWallet {
             .network(network.into())
             .create_wallet_no_persist()?;
 
-        let client = Builder::new(&url).build_async()?;
+        let client = Builder::new(url).build_async()?;
 
         Ok(EsploraWallet { wallet, client })
     }
@@ -48,22 +48,14 @@ impl EsploraWallet {
         internal_descriptor: String,
         url: &str,
     ) -> JsResult<EsploraWallet> {
-        Self::create(network, external_descriptor, internal_descriptor, url)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor, url).map_err(|e| JsError::new(&e.to_string()))
     }
 
-    pub fn from_seed(
-        seed: &[u8],
-        network: Network,
-        address_type: AddressType,
-        url: &str,
-    ) -> JsResult<EsploraWallet> {
+    pub fn from_seed(seed: &[u8], network: Network, address_type: AddressType, url: &str) -> JsResult<EsploraWallet> {
         let (external_descriptor, internal_descriptor) =
-            seed_to_descriptor(seed, network.into(), address_type.into())
-                .map_err(|e| JsError::new(&e.to_string()))?;
+            seed_to_descriptor(seed, network.into(), address_type.into()).map_err(|e| JsError::new(&e.to_string()))?;
 
-        Self::create(network, external_descriptor, internal_descriptor, url)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor, url).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn from_xpriv(
@@ -80,8 +72,7 @@ impl EsploraWallet {
             xpriv_to_descriptor(xprv, fingerprint, network.into(), address_type.into())
                 .map_err(|e| JsError::new(&e.to_string()))?;
 
-        Self::create(network, external_descriptor, internal_descriptor, url)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor, url).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn from_xpub(
@@ -98,8 +89,7 @@ impl EsploraWallet {
             xpub_to_descriptor(xpub, fingerprint, network.into(), address_type.into())
                 .map_err(|e| JsError::new(&e.to_string()))?;
 
-        Self::create(network, external_descriptor, internal_descriptor, url)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor, url).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn load(changeset: JsValue, url: &str) -> JsResult<EsploraWallet> {
@@ -111,17 +101,14 @@ impl EsploraWallet {
             None => return Err(JsError::new("Failed to load wallet, check the changeset")),
         };
 
-        let client = Builder::new(&url).build_async()?;
+        let client = Builder::new(url).build_async()?;
 
         Ok(EsploraWallet { wallet, client })
     }
 
     pub async fn full_scan(&mut self, stop_gap: usize, parallel_requests: usize) -> JsResult<()> {
         let request = self.wallet.start_full_scan();
-        let update = self
-            .client
-            .full_scan(request, stop_gap, parallel_requests)
-            .await?;
+        let update = self.client.full_scan(request, stop_gap, parallel_requests).await?;
 
         let now = (Date::now() / 1000.0) as u64;
         self.wallet.apply_update_at(update, Some(now))?;

--- a/src/bitcoin/snap_wallet.rs
+++ b/src/bitcoin/snap_wallet.rs
@@ -43,7 +43,7 @@ impl SnapWallet {
             .create_wallet_async(&mut persister)
             .await?;
 
-        let client = Builder::new(&url).build_async()?;
+        let client = Builder::new(url).build_async()?;
 
         Ok(SnapWallet {
             wallet,
@@ -61,7 +61,7 @@ impl SnapWallet {
             None => return Err(JsError::new("Failed to load wallet, check the changeset")),
         };
 
-        let client = Builder::new(&url).build_async()?;
+        let client = Builder::new(url).build_async()?;
 
         Ok(SnapWallet {
             wallet,
@@ -86,8 +86,7 @@ impl SnapWallet {
         url: &str,
     ) -> JsResult<SnapWallet> {
         let (external_descriptor, internal_descriptor) =
-            seed_to_descriptor(seed, network.into(), address_type.into())
-                .map_err(|e| JsError::new(&e.to_string()))?;
+            seed_to_descriptor(seed, network.into(), address_type.into()).map_err(|e| JsError::new(&e.to_string()))?;
 
         Self::create(network, external_descriptor, internal_descriptor, url).await
     }
@@ -128,10 +127,7 @@ impl SnapWallet {
 
     pub async fn full_scan(&mut self, stop_gap: usize, parallel_requests: usize) -> JsResult<()> {
         let request = self.wallet.start_full_scan();
-        let update = self
-            .client
-            .full_scan(request, stop_gap, parallel_requests)
-            .await?;
+        let update = self.client.full_scan(request, stop_gap, parallel_requests).await?;
 
         let now = (Date::now() / 1000.0) as u64;
         self.wallet.apply_update_at(update, Some(now))?;
@@ -198,9 +194,6 @@ impl SnapWallet {
     }
 
     pub async fn persist(&mut self) -> JsResult<bool> {
-        self.wallet
-            .persist_async(&mut self.persister)
-            .await
-            .map_err(Into::into)
+        self.wallet.persist_async(&mut self.persister).await.map_err(Into::into)
     }
 }

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -18,11 +18,7 @@ pub struct Wallet {
 
 #[wasm_bindgen]
 impl Wallet {
-    fn create<D>(
-        network: Network,
-        external_descriptor: D,
-        internal_descriptor: D,
-    ) -> Result<Wallet, anyhow::Error>
+    fn create<D>(network: Network, external_descriptor: D, internal_descriptor: D) -> Result<Wallet, anyhow::Error>
     where
         D: IntoWalletDescriptor + Send + Clone + 'static,
     {
@@ -38,17 +34,14 @@ impl Wallet {
         external_descriptor: String,
         internal_descriptor: String,
     ) -> JsResult<Wallet> {
-        Self::create(network, external_descriptor, internal_descriptor)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn from_seed(seed: &[u8], network: Network, address_type: AddressType) -> JsResult<Wallet> {
         let (external_descriptor, internal_descriptor) =
-            seed_to_descriptor(seed, network.into(), address_type.into())
-                .map_err(|e| JsError::new(&e.to_string()))?;
+            seed_to_descriptor(seed, network.into(), address_type.into()).map_err(|e| JsError::new(&e.to_string()))?;
 
-        Self::create(network, external_descriptor, internal_descriptor)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn from_xpriv(
@@ -64,8 +57,7 @@ impl Wallet {
             xpriv_to_descriptor(xprv, fingerprint, network.into(), address_type.into())
                 .map_err(|e| JsError::new(&e.to_string()))?;
 
-        Self::create(network, external_descriptor, internal_descriptor)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn from_xpub(
@@ -81,8 +73,7 @@ impl Wallet {
             xpub_to_descriptor(xpub, fingerprint, network.into(), address_type.into())
                 .map_err(|e| JsError::new(&e.to_string()))?;
 
-        Self::create(network, external_descriptor, internal_descriptor)
-            .map_err(|e| JsError::new(&e.to_string()))
+        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn load(changeset: JsValue) -> JsResult<Wallet> {

--- a/src/utils/descriptor.rs
+++ b/src/utils/descriptor.rs
@@ -10,14 +10,9 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
 use super::result::JsResult;
 
 #[wasm_bindgen]
-pub fn seed_to_descriptor(
-    seed: &[u8],
-    network: Network,
-    address_type: AddressType,
-) -> JsResult<DescriptorPair> {
-    let (external, internal) =
-        crate::bitcoin::seed_to_descriptor(seed, network.into(), address_type.into())
-            .map_err(|e| JsError::new(&e.to_string()))?;
+pub fn seed_to_descriptor(seed: &[u8], network: Network, address_type: AddressType) -> JsResult<DescriptorPair> {
+    let (external, internal) = crate::bitcoin::seed_to_descriptor(seed, network.into(), address_type.into())
+        .map_err(|e| JsError::new(&e.to_string()))?;
 
     Ok(DescriptorPair::new(
         external.0.to_string_with_secret(&external.1),
@@ -59,16 +54,12 @@ pub fn xpub_to_descriptor(
         crate::bitcoin::xpub_to_descriptor(xpub, fingerprint, network.into(), address_type.into())
             .map_err(|e| JsError::new(&e.to_string()))?;
 
-    Ok(DescriptorPair::new(
-        external.0.to_string(),
-        internal.0.to_string(),
-    ))
+    Ok(DescriptorPair::new(external.0.to_string(), internal.0.to_string()))
 }
 
 #[wasm_bindgen]
 pub fn seed_to_xpriv(seed: &[u8], network: Network) -> JsResult<String> {
-    let xprv = crate::bitcoin::seed_to_xpriv(seed, network.into())
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let xprv = crate::bitcoin::seed_to_xpriv(seed, network.into()).map_err(|e| JsError::new(&e.to_string()))?;
 
     Ok(xprv.to_string())
 }
@@ -76,8 +67,8 @@ pub fn seed_to_xpriv(seed: &[u8], network: Network) -> JsResult<String> {
 #[wasm_bindgen]
 pub fn slip10_to_extended(slip10: JsValue, network: Network) -> JsResult<String> {
     let node: SLIP10Node = from_value(slip10.clone())?;
-    let extended_key = crate::bitcoin::slip10_to_extended(node, network.into())
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let extended_key =
+        crate::bitcoin::slip10_to_extended(node, network.into()).map_err(|e| JsError::new(&e.to_string()))?;
 
     match &extended_key {
         ExtendedKey::Private(xprv) => Ok(xprv.0.to_string()),

--- a/tests/esplora.rs
+++ b/tests/esplora.rs
@@ -33,13 +33,9 @@ async fn test_esplora_wallet() {
     };
 
     let seed = Mnemonic::parse(MNEMONIC).unwrap().to_seed("");
-    let mut wallet = EsploraWallet::from_seed(&seed, NETWORK, ADDRESS_TYPE, esplora_url)
-        .expect("esplora_wallet");
+    let mut wallet = EsploraWallet::from_seed(&seed, NETWORK, ADDRESS_TYPE, esplora_url).expect("esplora_wallet");
 
-    wallet
-        .full_scan(STOP_GAP, PARALLEL_REQUESTS)
-        .await
-        .expect("full_scan");
+    wallet.full_scan(STOP_GAP, PARALLEL_REQUESTS).await.expect("full_scan");
 
     let address0 = wallet.peek_address(KeychainKind::External, 0);
     assert_eq!(

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -56,8 +56,7 @@ async fn test_xpriv_to_descriptor() {
     let xpriv = "tprv8g4stFEyX1zQoi4oNBdUFy4cDqWcyWu1kacHgK3RRvTdTPDm8HTxhERpV9JLTct69h4479xKJXm85SYkFZ4eMUsru5MdUNkeouuzbivKAJp";
     let fingerprint = "27f9035f";
 
-    let descriptors = xpriv_to_descriptor(xpriv, fingerprint, NETWORK, ADDRESS_TYPE)
-        .expect("xpriv_to_descriptor");
+    let descriptors = xpriv_to_descriptor(xpriv, fingerprint, NETWORK, ADDRESS_TYPE).expect("xpriv_to_descriptor");
 
     assert_eq!(
         descriptors.external(),
@@ -75,8 +74,7 @@ async fn test_xpub_to_descriptor() {
     let xpub = "tpubDCkv2fHDfPg5hB6bFqJ4fNiins2Z8r5vKtD4xq5irCG2HsUXkgHYsj3gfGTdvAv41hoJeXjfxu7EBQqZMm6SVkxztKFtaaE7HuLdkuL7KNq";
     let fingerprint = "27f9035f";
 
-    let descriptors =
-        xpub_to_descriptor(xpub, fingerprint, NETWORK, ADDRESS_TYPE).expect("xpub_to_descriptor");
+    let descriptors = xpub_to_descriptor(xpub, fingerprint, NETWORK, ADDRESS_TYPE).expect("xpub_to_descriptor");
 
     assert_eq!(
         descriptors.external(),
@@ -99,8 +97,7 @@ async fn test_wallet() {
     assert_eq!(balance.total(), 0);
 
     let initial_changeset_js = wallet.take_staged().expect("take_staged");
-    let initial_changeset: ChangeSet =
-        from_value(initial_changeset_js.clone()).expect("from_value");
+    let initial_changeset: ChangeSet = from_value(initial_changeset_js.clone()).expect("from_value");
     assert_eq!(initial_changeset.descriptor.unwrap().to_string(), "wpkh([27f9035f/84'/1'/0']tpubDCkv2fHDfPg5hB6bFqJ4fNiins2Z8r5vKtD4xq5irCG2HsUXkgHYsj3gfGTdvAv41hoJeXjfxu7EBQqZMm6SVkxztKFtaaE7HuLdkuL7KNq/0/*)#wle7e0wp");
     assert_eq!(
         initial_changeset.change_descriptor.unwrap().to_string(),
@@ -113,8 +110,6 @@ async fn test_wallet() {
     let address1 = wallet.reveal_next_address(KeychainKind::External);
     assert_eq!(address1.index(), 1);
 
-    let final_changeset_js = wallet
-        .take_merged(initial_changeset_js)
-        .expect("take_merged");
+    let final_changeset_js = wallet.take_merged(initial_changeset_js).expect("take_merged");
     assert!(!final_changeset_js.is_null() && !final_changeset_js.is_undefined());
 }


### PR DESCRIPTION
Performs linting and formatting using new `rustfmt` file:
- adds `rustfmt.toml`
- adds `rust-toolchain.toml`
- fixes `&url` issue double referencing.