### PR TITLE
chore: remove utility functions

### DIFF
--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -1,17 +1,13 @@
-use std::str::FromStr;
-
 use bdk_wallet::{descriptor::IntoWalletDescriptor, Wallet as BdkWallet};
-use bitcoin::bip32::{Fingerprint, Xpriv, Xpub};
 use js_sys::Date;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 
 use crate::{
-    bitcoin::{seed_to_descriptor, xpriv_to_descriptor, xpub_to_descriptor},
     result::JsResult,
     types::{
-        AddressInfo, AddressType, Balance, ChangeSet, CheckPoint, FullScanRequest, KeychainKind, Network, SyncRequest,
-        Update,
+        AddressInfo, Balance, ChangeSet, CheckPoint, DescriptorPair, FullScanRequest, KeychainKind, Network,
+        SyncRequest, Update,
     },
 };
 
@@ -22,7 +18,7 @@ pub struct Wallet {
 
 #[wasm_bindgen]
 impl Wallet {
-    fn create<D>(network: Network, external_descriptor: D, internal_descriptor: D) -> Result<Wallet, anyhow::Error>
+    fn _create<D>(network: Network, external_descriptor: D, internal_descriptor: D) -> Result<Wallet, anyhow::Error>
     where
         D: IntoWalletDescriptor + Send + Clone + 'static,
     {
@@ -33,51 +29,8 @@ impl Wallet {
         Ok(Wallet { wallet })
     }
 
-    pub fn from_descriptors(
-        network: Network,
-        external_descriptor: String,
-        internal_descriptor: String,
-    ) -> JsResult<Wallet> {
-        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
-    }
-
-    pub fn from_seed(seed: &[u8], network: Network, address_type: AddressType) -> JsResult<Wallet> {
-        let (external_descriptor, internal_descriptor) =
-            seed_to_descriptor(seed, network.into(), address_type.into()).map_err(|e| JsError::new(&e.to_string()))?;
-
-        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
-    }
-
-    pub fn from_xpriv(
-        extended_privkey: &str,
-        fingerprint: &str,
-        network: Network,
-        address_type: AddressType,
-    ) -> JsResult<Wallet> {
-        let xprv = Xpriv::from_str(extended_privkey).map_err(|e| JsError::new(&e.to_string()))?;
-        let fingerprint = Fingerprint::from_hex(fingerprint)?;
-
-        let (external_descriptor, internal_descriptor) =
-            xpriv_to_descriptor(xprv, fingerprint, network.into(), address_type.into())
-                .map_err(|e| JsError::new(&e.to_string()))?;
-
-        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
-    }
-
-    pub fn from_xpub(
-        extended_pubkey: &str,
-        fingerprint: &str,
-        network: Network,
-        address_type: AddressType,
-    ) -> JsResult<Wallet> {
-        let xpub = Xpub::from_str(extended_pubkey)?;
-        let fingerprint = Fingerprint::from_hex(fingerprint)?;
-
-        let (external_descriptor, internal_descriptor) =
-            xpub_to_descriptor(xpub, fingerprint, network.into(), address_type.into())
-                .map_err(|e| JsError::new(&e.to_string()))?;
-
-        Self::create(network, external_descriptor, internal_descriptor).map_err(|e| JsError::new(&e.to_string()))
+    pub fn create(network: Network, descriptors: DescriptorPair) -> JsResult<Wallet> {
+        Self::_create(network, descriptors.external(), descriptors.internal()).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn load(changeset: ChangeSet) -> JsResult<Wallet> {

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -1,4 +1,4 @@
-use bdk_wallet::{descriptor::IntoWalletDescriptor, Wallet as BdkWallet};
+use bdk_wallet::Wallet as BdkWallet;
 use js_sys::Date;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
@@ -18,19 +18,12 @@ pub struct Wallet {
 
 #[wasm_bindgen]
 impl Wallet {
-    fn _create<D>(network: Network, external_descriptor: D, internal_descriptor: D) -> Result<Wallet, anyhow::Error>
-    where
-        D: IntoWalletDescriptor + Send + Clone + 'static,
-    {
-        let wallet = BdkWallet::create(external_descriptor, internal_descriptor)
+    pub fn create(network: Network, descriptors: DescriptorPair) -> JsResult<Wallet> {
+        let wallet = BdkWallet::create(descriptors.external(), descriptors.internal())
             .network(network.into())
             .create_wallet_no_persist()?;
 
         Ok(Wallet { wallet })
-    }
-
-    pub fn create(network: Network, descriptors: DescriptorPair) -> JsResult<Wallet> {
-        Self::_create(network, descriptors.external(), descriptors.internal()).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn load(changeset: ChangeSet) -> JsResult<Wallet> {

--- a/tests/esplora.rs
+++ b/tests/esplora.rs
@@ -7,7 +7,7 @@ extern crate wasm_bindgen_test;
 use bdk_wasm::{
     bitcoin::{EsploraClient, Wallet},
     set_panic_hook,
-    types::{KeychainKind, Network},
+    types::{DescriptorPair, KeychainKind, Network},
 };
 use wasm_bindgen_test::*;
 
@@ -32,7 +32,7 @@ async fn test_esplora_client() {
     };
 
     let mut wallet =
-        Wallet::from_descriptors(NETWORK, EXTERNAL_DESC.to_string(), INTERNAL_DESC.to_string()).expect("wallet");
+        Wallet::create(NETWORK, DescriptorPair::new(EXTERNAL_DESC.into(), INTERNAL_DESC.into())).expect("wallet");
     let mut blockchain_client = EsploraClient::new(esplora_url).expect("esplora_client");
 
     let block_height = wallet.latest_checkpoint().height();

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -7,7 +7,7 @@ extern crate wasm_bindgen_test;
 use bdk_wallet::bip39::Mnemonic;
 use bdk_wasm::{
     bitcoin::Wallet,
-    set_panic_hook,
+    seed_to_descriptor, set_panic_hook,
     types::{AddressType, ChangeSet, KeychainKind, Network},
 };
 use wasm_bindgen_test::*;
@@ -23,7 +23,8 @@ async fn test_wallet() {
     set_panic_hook();
 
     let seed = Mnemonic::parse(MNEMONIC).unwrap().to_seed("");
-    let mut wallet = Wallet::from_seed(&seed, NETWORK, ADDRESS_TYPE).expect("wallet");
+    let descriptors = seed_to_descriptor(&seed, NETWORK, ADDRESS_TYPE).expect("seed_to_descriptor");
+    let mut wallet = Wallet::create(NETWORK, descriptors).expect("wallet");
 
     let balance = wallet.balance();
     assert_eq!(balance.total().to_sat(), 0);
@@ -48,7 +49,8 @@ async fn test_changeset() {
     set_panic_hook();
 
     let seed = Mnemonic::parse(MNEMONIC).unwrap().to_seed("");
-    let mut wallet = Wallet::from_seed(&seed, NETWORK, ADDRESS_TYPE).expect("wallet");
+    let descriptors = seed_to_descriptor(&seed, NETWORK, ADDRESS_TYPE).expect("seed_to_descriptor");
+    let mut wallet = Wallet::create(NETWORK, descriptors).expect("wallet");
 
     let mut changeset = wallet.take_staged().expect("initial_changeset");
     assert!(!changeset.is_empty());


### PR DESCRIPTION
Static utilities used to instantiate a new Wallet are not needed and are not compliant with the BDK API. This PR removes them as they are already exposed from the `utils` module. A single `create` function is not exposed to instantiate a new wallet. 