### PR TITLE
release: v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindevkit"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bdk_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoindevkit"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/MetaMask/bdk-wasm"
 description = "A modern, lightweight, descriptor-based wallet library in WebAssembly for browsers and Node"
 keywords = [


### PR DESCRIPTION
Release v0.1.2.

- BDK first stable version `v1.0.0`
- Send transactions (PSBT creation, signing and broadcasting)