### PR TITLE
chore: add `DEVELOPMENT.md` (MacOS specific sections) + add missing `rustup` target step

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,46 @@
+# Build on MacOS
+
+## Native toolchain setup
+
+On MacOS, you should replace the default `llvm` with the one from `brew`:
+
+```sh
+brew install llvm
+```
+
+We recommend creating a `.cargo` folder at the root of this repository with the following
+`config.toml` file:
+
+```toml
+[env]
+AR = "/opt/homebrew/opt/llvm/bin/llvm-ar"
+CC = "/opt/homebrew/opt/llvm/bin/clang"
+```
+
+Additionally, if you're using rust-analyzer in VSCode, you'll want to add the following to
+your `.vscode/settings.json` file:
+
+```json
+{
+  "rust-analyzer.server.extraEnv": {
+    "AR": "/opt/homebrew/opt/llvm/bin/llvm-ar",
+    "CC": "/opt/homebrew/opt/llvm/bin/clang"
+  },
+  "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+}
+```
+
+## `rustup` installation (using Homebrew)
+
+System-wide installation of `rust` might conflict with `brew`-managed `rustup` installation, see:
+- https://github.com/rust-lang/rustup/issues/1236
+- https://rust-lang.github.io/rustup/installation/other.html#homebrew
+
+To use `brew`-managed `rustup` package, you can use:
+
+```sh
+brew uninstall rust
+brew unlink rust
+brew install rustup
+export PATH="${PATH}:$(brew --prefix rustup)/bin" # .{bash,zsh}rc
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,9 @@ your `.vscode/settings.json` file:
 }
 ```
 
-## `rustup` installation (using Homebrew)
+## Troubleshooting
+
+### `rustup` installation (using Homebrew)
 
 System-wide installation of `rust` might conflict with `brew`-managed `rustup` installation, see:
 - https://github.com/rust-lang/rustup/issues/1236

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ On MacOS, you should replace the default `llvm` with the one from `brew`:
 brew install llvm
 ```
 
+> [!TIP]
+> System-wide installation of `rust` might and `rustup` might conflict with `brew`-managed
+> rust installs, see:
+> - https://github.com/rust-lang/rustup/issues/1236
+> - https://rust-lang.github.io/rustup/installation/other.html#homebrew
+>
+> You can use the following to use the `brew`-managed `rustup` package:
+> ```sh
+> brew uninstall rust
+> brew unlink rust
+> brew install rustup
+> export PATH="$PATH:$(brew --prefix rustup)/bin" # .{bash,zsh}rc
+> ```
+
 We recommend creating a `.cargo` folder at the root of the repo with the following `config.toml` file:
 
 ```toml
@@ -96,6 +110,13 @@ Additionally, if you're using rust-analyzer in VSCode, you'll want to add the fo
 ```
 
 ### Build with `wasm-pack build`
+
+> [!IMPORTANT]
+> You need the `wasm32-unknown-unknown` toolchain to be installed:
+>
+> ```sh
+> rustup target add wasm32-unknown-unknown
+> ```
 
 ```sh
 wasm-pack build

--- a/README.md
+++ b/README.md
@@ -69,45 +69,7 @@ This essentially means the library only supports [Esplora](https://github.com/bl
 
 #### MacOS special requirement
 
-On MacOS, you should replace the default `llvm` with the one from `brew`:
-
-```sh
-brew install llvm
-```
-
-> [!TIP]
-> System-wide installation of `rust` might and `rustup` might conflict with `brew`-managed
-> rust installs, see:
-> - https://github.com/rust-lang/rustup/issues/1236
-> - https://rust-lang.github.io/rustup/installation/other.html#homebrew
->
-> You can use the following to use the `brew`-managed `rustup` package:
-> ```sh
-> brew uninstall rust
-> brew unlink rust
-> brew install rustup
-> export PATH="$PATH:$(brew --prefix rustup)/bin" # .{bash,zsh}rc
-> ```
-
-We recommend creating a `.cargo` folder at the root of the repo with the following `config.toml` file:
-
-```toml
-[env]
-AR = "/opt/homebrew/opt/llvm/bin/llvm-ar"
-CC = "/opt/homebrew/opt/llvm/bin/clang"
-```
-
-Additionally, if you're using rust-analyzer in VSCode, you'll want to add the following to your `.vscode/settings.json` file:
-
-```json
-{
-  "rust-analyzer.server.extraEnv": {
-    "AR": "/opt/homebrew/opt/llvm/bin/llvm-ar",
-    "CC": "/opt/homebrew/opt/llvm/bin/clang"
-  },
-  "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
-}
-```
+Refers to [this section](./DEVELOPMENT.md#build-on-macos).
 
 ### Build with `wasm-pack build`
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ yarn add bitcoindevkit
 
 ## Notes on WASM Specific Considerations
 
-> [!WARNING]  
+> [!WARNING]
 > There are several limitations to using BDK in WASM. Basically any functionality that requires the OS standard library is not directly available in WASM. However, there are viable workarounds documented below. Some key limitations include:
 >
 > - No access to the file system


### PR DESCRIPTION
### Description

Updating the README regarding the MacOS build setup and also adding a step about installing the `wasm32-unknown-unknown` toolchain with `rustup`.