### PR TITLE
fix(ci): remove use of `--immutable-cache` (`yarn`)

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: tests/node/yarn.lock
       - name: Install
         working-directory: tests/node
-        run: yarn install --immutable --immutable-cache
+        run: yarn install --immutable
       - name: Lint
         working-directory: tests/node
         run: yarn lint


### PR DESCRIPTION
### Description

Remove the use of the `--immutable-cache` option for node-based steps.

### Notes to the reviewers

In full-typescript repos, we do have a `prepare` steps that actually omit this option to pre-fill the cache and use `--immutable-cache` on other steps (that are dependent to `prepare`), see:
- https://github.com/MetaMask/accounts/blob/main/.github/workflows/build-lint-test.yml#L7-L22
- https://github.com/MetaMask/accounts/blob/main/.github/workflows/build-lint-test.yml#L32-L33