### PR TITLE
Add as_bytes to ScriptBuf

### DIFF
--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -128,6 +128,10 @@ impl ScriptBuf {
     pub fn to_string(&self) -> String {
         self.0.to_string()
     }
+
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
+    }
 }
 
 impl From<BdkScriptBuf> for ScriptBuf {


### PR DESCRIPTION
Needed for payjoin (PDK wasm bindings)

There is special bitcoin logic to convert to/from string/bytes,
only having toString is quite limiting