### PR TITLE
feat: improved TxBuilder and Psbt

### DIFF
--- a/src/bitcoin/tx_builder.rs
+++ b/src/bitcoin/tx_builder.rs
@@ -1,8 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use bdk_wallet::{
-    bitcoin::ScriptBuf as BdkScriptBuf, error::CreateTxError, TxOrdering as BdkTxOrdering, Wallet as BdkWallet,
-};
+use bdk_wallet::{error::CreateTxError, TxOrdering as BdkTxOrdering, Wallet as BdkWallet};
 use serde::Serialize;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -22,9 +20,9 @@ pub struct TxBuilder {
     unspendable: Vec<OutPoint>,
     fee_rate: FeeRate,
     drain_wallet: bool,
-    drain_to: Option<BdkScriptBuf>,
+    drain_to: Option<ScriptBuf>,
     allow_dust: bool,
-    ordering: BdkTxOrdering,
+    ordering: TxOrdering,
 }
 
 #[wasm_bindgen]
@@ -39,7 +37,7 @@ impl TxBuilder {
             drain_wallet: false,
             allow_dust: false,
             drain_to: None,
-            ordering: BdkTxOrdering::default(),
+            ordering: BdkTxOrdering::default().into(),
         }
     }
 
@@ -100,7 +98,7 @@ impl TxBuilder {
     /// If you choose not to set any recipients, you should provide the utxos that the
     /// transaction should spend via [`add_utxos`].
     pub fn drain_to(mut self, script_pubkey: ScriptBuf) -> Self {
-        self.drain_to = Some(script_pubkey.into());
+        self.drain_to = Some(script_pubkey);
         self
     }
 
@@ -114,7 +112,7 @@ impl TxBuilder {
 
     /// Choose the ordering for inputs and outputs of the transaction
     pub fn ordering(mut self, ordering: TxOrdering) -> Self {
-        self.ordering = ordering.into();
+        self.ordering = ordering;
         self
     }
 
@@ -137,7 +135,7 @@ impl TxBuilder {
         }
 
         if let Some(drain_recipient) = self.drain_to {
-            builder.drain_to(drain_recipient);
+            builder.drain_to(drain_recipient.into());
         }
 
         let psbt = builder.finish()?;

--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -4,10 +4,7 @@ use bdk_wallet::{
     bitcoin::{Address as BdkAddress, AddressType as BdkAddressType, Network as BdkNetwork, ScriptBuf as BdkScriptBuf},
     AddressInfo as BdkAddressInfo,
 };
-use bitcoin::{
-    address::ParseError,
-    hashes::{sha256, Hash},
-};
+use bitcoin::address::ParseError;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
@@ -104,11 +101,6 @@ impl Address {
     pub fn script_pubkey(&self) -> ScriptBuf {
         self.0.script_pubkey().into()
     }
-
-    #[wasm_bindgen(getter)]
-    pub fn scripthash(&self) -> String {
-        sha256::Hash::hash(self.0.script_pubkey().as_bytes()).to_string()
-    }
 }
 
 impl From<BdkAddress> for Address {
@@ -159,6 +151,15 @@ impl Deref for ScriptBuf {
 
 #[wasm_bindgen]
 impl ScriptBuf {
+    pub fn from_hex(s: &str) -> JsResult<Self> {
+        let script = BdkScriptBuf::from_hex(s)?;
+        Ok(script.into())
+    }
+
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        BdkScriptBuf::from_bytes(bytes).into()
+    }
+
     #[allow(clippy::inherent_to_string)]
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {

--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -4,7 +4,10 @@ use bdk_wallet::{
     bitcoin::{Address as BdkAddress, AddressType as BdkAddressType, Network as BdkNetwork, ScriptBuf as BdkScriptBuf},
     AddressInfo as BdkAddressInfo,
 };
-use bitcoin::address::ParseError;
+use bitcoin::{
+    address::ParseError,
+    hashes::{sha256, Hash},
+};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
@@ -96,6 +99,16 @@ impl Address {
     pub fn to_string(&self) -> String {
         self.0.to_string()
     }
+
+    #[wasm_bindgen(getter)]
+    pub fn script_pubkey(&self) -> ScriptBuf {
+        self.0.script_pubkey().into()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn scripthash(&self) -> String {
+        sha256::Hash::hash(self.0.script_pubkey().as_bytes()).to_string()
+    }
 }
 
 impl From<BdkAddress> for Address {
@@ -133,6 +146,7 @@ impl From<ParseError> for BdkError {
 /// `ScriptBuf` is the most common script type that has the ownership over the contents of the
 /// script. It has a close relationship with its borrowed counterpart, [`Script`].
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct ScriptBuf(BdkScriptBuf);
 
 impl Deref for ScriptBuf {
@@ -153,6 +167,18 @@ impl ScriptBuf {
 
     pub fn as_bytes(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()
+    }
+
+    pub fn to_asm_string(&self) -> String {
+        self.0.to_asm_string()
+    }
+
+    pub fn to_hex_string(&self) -> String {
+        self.0.to_hex_string()
+    }
+
+    pub fn is_op_return(&self) -> bool {
+        self.0.is_op_return()
     }
 }
 

--- a/tests/node/integration/errors.test.ts
+++ b/tests/node/integration/errors.test.ts
@@ -1,0 +1,51 @@
+import {
+  Address,
+  Amount,
+  BdkError,
+  BdkErrorCode,
+} from "../../../pkg/bitcoindevkit";
+import type { Network } from "../../../pkg/bitcoindevkit";
+
+describe("Wallet", () => {
+  const network: Network = "testnet";
+
+  it("catches fine-grained address errors", () => {
+    try {
+      Address.from_string(
+        "tb1qd28npep0s8frcm3y7dxqajkcy2m40eysplyr9v",
+        "bitcoin"
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(BdkError);
+
+      const { code, message, data } = error;
+      expect(code).toBe(BdkErrorCode.NetworkValidation);
+      expect(message.startsWith("validation error")).toBe(true);
+      expect(data).toBeUndefined();
+    }
+
+    try {
+      Address.from_string("notAnAddress", network);
+    } catch (error) {
+      expect(error).toBeInstanceOf(BdkError);
+
+      const { code, message, data } = error;
+      expect(code).toBe(BdkErrorCode.Base58);
+      expect(message.startsWith("base58 error")).toBe(true);
+      expect(data).toBeUndefined();
+    }
+  });
+
+  it("catches fine-grained amount errors", () => {
+    try {
+      Amount.from_btc(-100000000);
+    } catch (error) {
+      expect(error).toBeInstanceOf(BdkError);
+
+      const { code, message, data } = error;
+      expect(code).toBe(BdkErrorCode.OutOfRange);
+      expect(message.startsWith("amount out of range")).toBe(true);
+      expect(data).toBeUndefined();
+    }
+  });
+});

--- a/tests/node/integration/utilities.test.ts
+++ b/tests/node/integration/utilities.test.ts
@@ -3,7 +3,6 @@ import {
   Network,
   seed_to_descriptor,
   seed_to_xpriv,
-  Wallet,
   xpriv_to_descriptor,
   xpub_to_descriptor,
 } from "../../../pkg/bitcoindevkit";
@@ -11,35 +10,10 @@ import { mnemonicToSeedSync } from "bip39";
 
 describe("Utilities", () => {
   const addressType: AddressType = "p2wpkh";
-  const network: Network = "bitcoin";
+  const network: Network = "testnet";
   const seed = mnemonicToSeedSync(
-    "spread raise short crane omit tent fringe mandate neglect detail suspect cradle"
+    "journey embrace permit coil indoor stereo welcome maid movie easy clock spider tent slush bright luxury awake waste legal modify awkward answer acid goose"
   );
-
-  it.only("test", async () => {
-    const desc = seed_to_descriptor(seed, network, "p2wpkh");
-
-    const w = Wallet.create(network, desc.external, desc.internal);
-    const eaddresses = w.reveal_addresses_to("external", 2);
-    const iaddresses = w.reveal_addresses_to("internal", 2);
-
-    eaddresses.forEach((add) => {
-      console.log(
-        add.address.toString(),
-        add.address.scripthash,
-        add.address.script_pubkey.toString(),
-        add.address.script_pubkey.to_hex_string()
-      );
-    });
-    iaddresses.forEach((add) => {
-      console.log(
-        add.address.toString(),
-        add.address.scripthash,
-        add.address.script_pubkey.toString(),
-        add.address.script_pubkey.to_hex_string()
-      );
-    });
-  });
 
   it("generates xpriv from seed", async () => {
     const xpriv = seed_to_xpriv(seed, network);

--- a/tests/node/integration/utilities.test.ts
+++ b/tests/node/integration/utilities.test.ts
@@ -3,6 +3,7 @@ import {
   Network,
   seed_to_descriptor,
   seed_to_xpriv,
+  Wallet,
   xpriv_to_descriptor,
   xpub_to_descriptor,
 } from "../../../pkg/bitcoindevkit";
@@ -10,10 +11,35 @@ import { mnemonicToSeedSync } from "bip39";
 
 describe("Utilities", () => {
   const addressType: AddressType = "p2wpkh";
-  const network: Network = "testnet";
+  const network: Network = "bitcoin";
   const seed = mnemonicToSeedSync(
-    "journey embrace permit coil indoor stereo welcome maid movie easy clock spider tent slush bright luxury awake waste legal modify awkward answer acid goose"
+    "spread raise short crane omit tent fringe mandate neglect detail suspect cradle"
   );
+
+  it.only("test", async () => {
+    const desc = seed_to_descriptor(seed, network, "p2wpkh");
+
+    const w = Wallet.create(network, desc.external, desc.internal);
+    const eaddresses = w.reveal_addresses_to("external", 2);
+    const iaddresses = w.reveal_addresses_to("internal", 2);
+
+    eaddresses.forEach((add) => {
+      console.log(
+        add.address.toString(),
+        add.address.scripthash,
+        add.address.script_pubkey.toString(),
+        add.address.script_pubkey.to_hex_string()
+      );
+    });
+    iaddresses.forEach((add) => {
+      console.log(
+        add.address.toString(),
+        add.address.scripthash,
+        add.address.script_pubkey.toString(),
+        add.address.script_pubkey.to_hex_string()
+      );
+    });
+  });
 
   it("generates xpriv from seed", async () => {
     const xpriv = seed_to_xpriv(seed, network);

--- a/tests/node/integration/wallet.test.ts
+++ b/tests/node/integration/wallet.test.ts
@@ -63,7 +63,9 @@ describe("Wallet", () => {
       wallet
         .build_tx()
         .fee_rate(new FeeRate(BigInt(1)))
-        .add_recipient(new Recipient(recipientAddress, sendAmount))
+        .add_recipient(
+          new Recipient(recipientAddress.script_pubkey, sendAmount)
+        )
         .finish();
     } catch (error) {
       expect(error).toBeInstanceOf(BdkError);

--- a/tests/node/integration/wallet.test.ts
+++ b/tests/node/integration/wallet.test.ts
@@ -75,44 +75,4 @@ describe("Wallet", () => {
       expect(data.available).toBeDefined();
     }
   });
-
-  it("catches fine-grained address errors", () => {
-    try {
-      Address.from_string(
-        "tb1qd28npep0s8frcm3y7dxqajkcy2m40eysplyr9v",
-        "bitcoin"
-      );
-    } catch (error) {
-      expect(error).toBeInstanceOf(BdkError);
-
-      const { code, message, data } = error;
-      expect(code).toBe(BdkErrorCode.NetworkValidation);
-      expect(message.startsWith("validation error")).toBe(true);
-      expect(data).toBeUndefined();
-    }
-
-    try {
-      Address.from_string("notAnAddress", network);
-    } catch (error) {
-      expect(error).toBeInstanceOf(BdkError);
-
-      const { code, message, data } = error;
-      expect(code).toBe(BdkErrorCode.Base58);
-      expect(message.startsWith("base58 error")).toBe(true);
-      expect(data).toBeUndefined();
-    }
-  });
-
-  it("catches fine-grained amount errors", () => {
-    try {
-      Amount.from_btc(-100000000);
-    } catch (error) {
-      expect(error).toBeInstanceOf(BdkError);
-
-      const { code, message, data } = error;
-      expect(code).toBe(BdkErrorCode.OutOfRange);
-      expect(message.startsWith("amount out of range")).toBe(true);
-      expect(data).toBeUndefined();
-    }
-  });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds additional exports to the library in the TxBuilder and Psbt types, allowing to pass ScriptBuf instead of Address for a Recipient (more generic) and ordering. 
On the Psbt side, alllows for combining and identifying whether an output is an OP_RETURN.